### PR TITLE
Update base image to use JDK instead of JRE

### DIFF
--- a/jenkins-slave-base/Dockerfile
+++ b/jenkins-slave-base/Dockerfile
@@ -9,7 +9,7 @@ RUN yum update -y && \
 
 # Install Packages
 RUN yum install -y git && \
-	yum install -y java-1.8.0-openjdk && \
+	yum install -y java-1.8.0-openjdk-devel.x86_64 && \
 	yum install -y sudo && \
 	yum clean all
 

--- a/sbt/Dockerfile
+++ b/sbt/Dockerfile
@@ -20,12 +20,12 @@ ENV JENKINS_HOME /home/jenkins
 ARG MAJOR_MINOR_VERSION
 ARG BASE_URL=https://sbt.bintray.com/rpm/
 
+ENV JAVA_HOME "/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.191.b12-1.el7_6.x86_64"
+ENV PATH "${JAVA_HOME}/bin:${PATH}"
+
 RUN curl -fsSL -o /tmp/sbt-${TOOL_VERSION}.rpm ${BASE_URL}/sbt-${TOOL_VERSION}.rpm && \
   yum install -y /tmp/sbt-${TOOL_VERSION}.rpm && \
   yum clean all
-
-ENV JAVA_HOME "/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.191.b12-1.el7_6.x86_64"
-ENV PATH "${JAVA_HOME}/bin:${PATH}"
 
 # The location of global sbtopts is dependent on the version of SBT (rpm) being installed
 # As of 2018/07/24, there are 29 versions of the SBT rpm available on bintray

--- a/sbt/Dockerfile
+++ b/sbt/Dockerfile
@@ -24,6 +24,9 @@ RUN curl -fsSL -o /tmp/sbt-${TOOL_VERSION}.rpm ${BASE_URL}/sbt-${TOOL_VERSION}.r
   yum install -y /tmp/sbt-${TOOL_VERSION}.rpm && \
   yum clean all
 
+ENV JAVA_HOME "/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.191.b12-1.el7_6.x86_64"
+ENV PATH "${JAVA_HOME}/bin:${PATH}"
+
 # The location of global sbtopts is dependent on the version of SBT (rpm) being installed
 # As of 2018/07/24, there are 29 versions of the SBT rpm available on bintray
 # 10 versions use /usr/share/sbt-launcher-packaging/conf    (which is symlinked to /etc/sbt-launcher-packaging)


### PR DESCRIPTION
javac is needed by the sbt 1.2.4 image and in it's absence 
'sbt compile' fails

Additionally, it was discovered that the current jenkins-slave-base
was using an older (java-1.8.0-openjdk-1.8.0.181-3.b13.el7_5.x86_64) 
version of *JRE*. Changes done to the base image:
    1. Use full JDK instead of JRE
    2. Rebuild image so that the latest JDK is pulled in. At the time
       of this commit this was: java-1.8.0-openjdk-devel.x86_64 1:1.8.0.191.b12-1.el7_6