### PR TITLE
Amend the python build to create executable linked to shared library

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -17,6 +17,9 @@ LABEL uk.gov.ons.image.version="${TOOL_VERSION}"
 ARG SHA
 ARG BASE_URL=https://www.python.org/ftp/python/${TOOL_VERSION}/
 
+
+ENV LD_RUN_PATH /usr/local/lib
+
 RUN yum install -y \
         gcc \
         openssl-devel \
@@ -29,5 +32,8 @@ RUN mkdir -p /usr/src/python \
     && tar -xzf /tmp/python.tgz -C /usr/src/python --strip-components=1 \
     && rm -f /tmp/python.tgz \
     && cd /usr/src/python \
-    && ./configure --enable-optimizations \
-    && make altinstall
+    && ./configure --enable-shared --enable-optimizations \
+    && make \
+    && make install \
+    && python -V
+


### PR DESCRIPTION
This commit fixes the issue that the python executable built requires
specifiying the LD_LIBRARY_PATH to load the correct library versions.

This issue is seen by comparing the output of `python -V` with
`LD_LIBRARY_PATH=/usr/local/lib python -V` . The former returns an
incorrect version (2.7.5) whereas the latter return the correct version
(2.7.15).

The default prefix when building python from source is /usr/local.
However the executable built loads the shared libraries from /lib64
(symlinked to /usr/lib64) which ends up loading the (incorrect) system
libpython2.7.so instead of loading it from the one that is built in
/usr/local/lib

The libraries being loaded by the executable are visible by executing:
For the correctly built exectuable it is :
```
[root@90fbc9dd6cfa /]# ldd /usr/local/bin/python
	libpython2.7.so.1.0 => /usr/local/lib/libpython2.7.so.1.0 (0x00007fedc6348000)
```
whereas for the current version (before this commit) the so is loaded
from /lib64 (-> /usr/lib64)

The fix is to either:
1. Specify the library path like so before invoking the python
exectuable:
  `LD_LIBRARY_PATH=/usr/local/lib /usr/local/bin/python -V`

OR,

2. Specify the library path at compile time using LD_RUN_PATH (as done
in this commit) so that it does not need to be specified at runtime and
does not require alterations to existing Jenkinsfile