### PR TITLE
Create a python v3.6.1 image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -121,6 +121,14 @@ services:
     image: onsdigital/jenkins-slave-python:3.6.0
     depends_on:
       - jenkins-slave-base
+  python_3.6.1:
+    build:
+      context: ./python
+      args:
+        TOOL_VERSION: 3.6.1
+    image: onsdigital/jenkins-slave-python:3.6.1
+    depends_on:
+      - jenkins-slave-base
   python_3.6.3:
     build:
       context: ./python

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -33,7 +33,7 @@ RUN mkdir -p /usr/src/python \
     && tar -xzf /tmp/python.tgz -C /usr/src/python --strip-components=1 \
     && rm -f /tmp/python.tgz \
     && cd /usr/src/python \
-    && ./configure --with-ensurepip=install --enable-shared --enable-optimizations \
+    && ./configure --with-ensurepip=install --enable-shared \
     && make \
     && make install \
     && python -V


### PR DESCRIPTION
'enable-optimizations' had to be removed since building from source with
both enable-optimizations and enable-shared does not work. This is
currently an open issue:

https://bugs.python.org/issue29712