### PR TITLE
Add the jq (v1.6) utility to enable parsing json from command-line

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -176,3 +176,11 @@ services:
     image: onsdigital/jenkins-slave-sbt:1.1.6
     depends_on:
       - scala_2-12-6
+  jq_1-6:
+    build:
+      context: ./jq
+      args:
+        TOOL_VERSION: 1.6
+    image: onsdigital/jenkins-slave-jq:1.6
+    depends_on:
+      - jenkins-slave-base

--- a/jq/Dockerfile
+++ b/jq/Dockerfile
@@ -1,0 +1,21 @@
+FROM onsdigital/jenkins-slave-base
+
+ARG TOOL_VERSION
+
+LABEL uk.gov.ons.image.name="jenkins-slave-jq"
+LABEL uk.gov.ons.image.description="A Jenkins slave with JQ"
+LABEL uk.gov.ons.image.version="${TOOL_VERSION}"
+
+
+RUN yum install -y wget && \
+    yum install -y gpg && \
+    wget --no-check-certificate https://raw.githubusercontent.com/stedolan/jq/master/sig/jq-release.key -O /tmp/jq-release.key && \
+    wget --no-check-certificate https://raw.githubusercontent.com/stedolan/jq/master/sig/v${TOOL_VERSION}/jq-linux64.asc -O /tmp/jq-linux64.asc && \
+    wget --no-check-certificate https://github.com/stedolan/jq/releases/download/jq-${TOOL_VERSION}/jq-linux64 -O /tmp/jq-linux64 && \
+    gpg --import /tmp/jq-release.key && \
+    gpg --verify /tmp/jq-linux64.asc /tmp/jq-linux64 && \
+    cp /tmp/jq-linux64 /usr/bin/jq && \
+    chmod +x /usr/bin/jq && \
+    rm -f /tmp/jq-release.key && \
+    rm -f /tmp/jq-linux64.asc && \
+    rm -f /tmp/jq-linux64


### PR DESCRIPTION
This PR adds an image that has jq from the releases published by https://github.com/stedolan/jq

The docker image installs the binary directly from the releases published by the aforementioned 
repository.

The initial use case for adding this utility was to allow parsing the JSON response from a call
to the REST API of the repository manager, but this utility can be used to parse JSON regardless
of the source.


