### PR TITLE
Update makefile to include checks for all images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ verify:
 	docker run -it onsdigital/jenkins-slave-node:v9.9.0 node --version
 	docker run -it onsdigital/jenkins-slave-scala:2.11.8 scala -version
 	docker run -it onsdigital/jenkins-slave-scala:2.12.6 scala -version
-	docker run -it onsdigital/jenkins-slave-sbt:0.13.13 sbt -version
-	docker run -it onsdigital/jenkins-slave-sbt:1.1.6 sbt -version
+	docker run -it onsdigital/jenkins-slave-sbt:0.13.13 sbt sbtVersion
+	docker run -it onsdigital/jenkins-slave-sbt:1.1.6 sbt sbtVersion
 	docker run -it onsdigital/jenkins-slave-python:2.7.15 /usr/local/bin/python2.7 -V
 	docker run -it onsdigital/jenkins-slave-python:3.3.0 /usr/local/bin/python3.3 -V
 

--- a/Makefile
+++ b/Makefile
@@ -17,14 +17,21 @@ verify:
 	docker run -it onsdigital/jenkins-slave-cf-cli:latest cf --version
 	docker run -it onsdigital/jenkins-slave-maven:3.2.5 mvn --version
 	docker run -it onsdigital/jenkins-slave-maven:3.5.4 mvn --version
+	docker run -it onsdigital/jenkins-slave-maven:3.6.0 mvn --version
 	docker run -it onsdigital/jenkins-slave-node:v6.11.5 node --version
 	docker run -it onsdigital/jenkins-slave-node:v9.9.0 node --version
 	docker run -it onsdigital/jenkins-slave-scala:2.11.8 scala -version
 	docker run -it onsdigital/jenkins-slave-scala:2.12.6 scala -version
+	docker run -it onsdigital/jenkins-slave-scala:2.12.7 scala -version
 	docker run -it onsdigital/jenkins-slave-sbt:0.13.13 sbt sbtVersion
 	docker run -it onsdigital/jenkins-slave-sbt:1.1.6 sbt sbtVersion
+	docker run -it onsdigital/jenkins-slave-sbt:1.2.4 sbt sbtVersion
 	docker run -it onsdigital/jenkins-slave-python:2.7.15 /usr/local/bin/python2.7 -V
 	docker run -it onsdigital/jenkins-slave-python:3.3.0 /usr/local/bin/python3.3 -V
+	docker run -it onsdigital/jenkins-slave-python:3.6.0 /usr/local/bin/python3.6 -V
+	docker run -it onsdigital/jenkins-slave-python:3.6.1 /usr/local/bin/python3.6 -V
+	docker run -it onsdigital/jenkins-slave-python:3.6.3 /usr/local/bin/python3.6 -V
+	docker run -it onsdigital/jenkins-slave-jq:1.6 jq --version
 
 test: clean all verify
 


### PR DESCRIPTION
This ensures that the travis ci builds (which consume the makefile
target 'test'), test all the images.

This makefile should be updated everytime a new image or tool is added.