### PR TITLE
Remove unused Python versions 3.3.0, 3.6.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,11 +53,10 @@ SCALA:
 # -----------------------------------------------------------------------------------------------------
 PYTHON_VERIFY_COMMAND_OTHER=python_version -V
 PYTHON_VERIFY_COMMAND=python3.6 -V
-PYTHON_VERSION_LIST=3.6.0 3.6.1 3.6.3
+PYTHON_VERSION_LIST=3.6.0 3.6.1
 PYTHON_DOCKER_IMAGE=onsdigital/jenkins-slave-python
 PYTHON:
-	$(DOCKER) $(DOCKER_FLAGS) onsdigital/jenkins-slave-python:2.7.15  ${PYTHON_VERIFY_COMMAND_OTHER:_version=2.7}
-	$(DOCKER) $(DOCKER_FLAGS) onsdigital/jenkins-slave-python:3.3.0   ${PYTHON_VERIFY_COMMAND_OTHER:_version=3.3}
+	#$(DOCKER) $(DOCKER_FLAGS) onsdigital/jenkins-slave-python:2.7.15  ${PYTHON_VERIFY_COMMAND_OTHER:_version=2.7}
 	$(call run_docker_meta,$@)
 # -----------------------------------------------------------------------------------------------------
 
@@ -71,7 +70,7 @@ PYTHON:
 # This function iterates through the versions in $1, and for each runs a container and executes the command specified
 # by $3
 define run_docker
-    { \
+    @{ \
     	for version in $(1); do \
     		printf "\n\n************************* Checking image $(2):$${version} with command $(3) \n"; \
     		$(DOCKER) $(DOCKER_FLAGS) $(2):$${version} 	$(3) ; \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,22 +97,6 @@ services:
     image: onsdigital/jenkins-slave-python:2.7.15
     depends_on:
       - jenkins-slave-base
-  python_3.3.0:
-    build:
-      context: ./python
-      args:
-        TOOL_VERSION: 3.3.0
-    image: onsdigital/jenkins-slave-python:3.3.0
-    depends_on:
-      - jenkins-slave-base
-  python_3.4.0:
-    build:
-      context: ./python
-      args:
-        TOOL_VERSION: 3.4.0
-    image: onsdigital/jenkins-slave-python:3.4.0
-    depends_on:
-      - jenkins-slave-base
   python_3.6.0:
     build:
       context: ./python
@@ -127,14 +111,6 @@ services:
       args:
         TOOL_VERSION: 3.6.1
     image: onsdigital/jenkins-slave-python:3.6.1
-    depends_on:
-      - jenkins-slave-base
-  python_3.6.3:
-    build:
-      context: ./python
-      args:
-        TOOL_VERSION: 3.6.3
-    image: onsdigital/jenkins-slave-python:3.6.3
     depends_on:
       - jenkins-slave-base
   #  r_3.5.0-1:


### PR DESCRIPTION
Python images build python from source which involves running a
non-trivial number of tests. Verifying the python images, thus takes up,
a substantial portion of the build time. Removing unused python
versions should speed up the builds.